### PR TITLE
Apply rename when using multiple filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ function processQuerystringItem(fieldName, value) {
             var subValue = helpers.replace_operator_values(value[i], fieldName);
             if(subValue.value) {
                 result = {};
-                result[fieldName] = subValue.value;
+                if(subValue.rename) {
+                    result[subValue.rename] = subValue.value;
+                } else {
+                    result[fieldName] = subValue.value;
+                }
                 processedValues.push(result);
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -416,6 +416,23 @@ suite('The filter', function () {
         done();
     });
 
+    test('should allow a new operator that replaces the fieldname when there are multiple filters on the same field', function (done) {
+        // define a function that returns an operator $thing, that doubles the value
+        var thingfn = function(value, helpers, operatorName){
+            return value * 2;
+        };
+        // Set for the lifetime of qf
+        qf.extendOperators({'thing': {'fn': thingfn, 'ns': '$thing', rename: "foo"}});
+        var out = qf.filter('price=3&price=__thing_2');
+        should.exist(out);
+        out.should.have.property('$and');
+        out.$and.should.have.length(2);
+        out.$and[0].should.have.property("price", "3");
+        out.$and[1].should.have.property('foo');
+        out.$and[1].foo.should.have.property('$thing', 4);
+        done();
+    });
+
     test('should allow a new operator', function (done) {
         // define a function that returns an operator $thing, that doubles the value
         var thingfn = function(value, helpers, operatorName){


### PR DESCRIPTION
The case where multiple queries are on the same field didn't have the rename applied